### PR TITLE
Update fixed_point tests to include check for division

### DIFF
--- a/SingleSource/UnitTests/fixed_point.cpp
+++ b/SingleSource/UnitTests/fixed_point.cpp
@@ -187,6 +187,18 @@ int main(void) {
   print_float("mul int overflow signed", small_unsigned * 3);
   print_float("mul fp overflow signed", small_unsigned * 3.3_8_8);
 
+  // Division checks
+  auto divsignval = -12.0_8_8;
+  auto divunsignval = 12.0_8_8;
+  print_float("div int signed no remainder", divsignval / 2);
+  print_float("div fp signed no rounding", divsignval / 2.5_8_8);
+  print_float("div int large signed", small_signed / 3);
+  print_float("div fp large signed", small_signed / 3.3_8_8);
+  print_float("div int unsigned no remainder", divunsignval / 2);
+  print_float("div fp unsigned no rounding", divunsignval / 2.5_8_8);
+  print_float("div int large unsigned", small_unsigned / 3);
+  print_float("div fp large unsigned", small_unsigned / 3.3_u8_8);
+
   // Comparison checks
   printf("sign < unsigned %s\n", (-10.0_8_8 < 10.0_8_8) ? "true" : "false");
   printf("sign > unsigned %s\n", (-10.0_8_8 > 10.0_8_8) ? "true" : "false");

--- a/SingleSource/UnitTests/fixed_point.reference_output
+++ b/SingleSource/UnitTests/fixed_point.reference_output
@@ -49,6 +49,14 @@ mul int small signed 32.39
 mul fp small signed 35.59
 mul int overflow signed 88.29
 mul fp overflow signed 147.70
+div int signed no remainder -6.00
+div fp signed no rounding -4.80
+div int large signed -16.93
+div fp large signed -15.41
+div int unsigned no remainder 6.00
+div fp unsigned no rounding 4.80
+div int large unsigned 66.70
+div fp large unsigned 60.69
 sign < unsigned true
 sign > unsigned false
 sign == unsigned false


### PR DESCRIPTION
See the corresponding PR in llvm-mos-sdk for the bug fix in fixed_point.h that these new test cases are intended to verify.